### PR TITLE
Fix redirect uri for fastapi-google-auth

### DIFF
--- a/fastapi-google-login/README.md
+++ b/fastapi-google-login/README.md
@@ -11,6 +11,6 @@ into `.env`, then run:
 
 When register your Google OAuth Client, remember to put:
 
-    http://127.0.0.1:8000/
+    http://127.0.0.1:8000/auth
 
 into the client redirect uris list.


### PR DESCRIPTION
Google's OAtuh 2.0 policy states that the redirect uri be /auth. Although this is implemented in the app.py, it needs to be updated in the Readme file. 